### PR TITLE
feat: update APK download link to the correct URL

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,7 +61,7 @@ export default function Home() {
 
   const handleDownload = () => {
     setIsDownloading(true);
-    const apkUrl = 'https://expo.dev/artifacts/eas/ofedEkWy4pyqPMvF3oYVMm.apk';
+    const apkUrl = 'https://expo.dev/artifacts/eas/oHd6weQKymLt3AVchnFdES.apk';
     const link = document.createElement('a');
     link.href = apkUrl;
     link.download = 'BudgetMate.apk';


### PR DESCRIPTION
This pull request updates the APK download link in the `Home` page. The new URL ensures users will download the latest version of the `BudgetMate` app.

* Updated the `apkUrl` in the `handleDownload` function in `src/app/page.tsx` to point to a new APK artifact.